### PR TITLE
Fix Class::MethodMaker build issue. Use $HOME if /etc/passwd doesn't contain current user.

### DIFF
--- a/deps/Class-MethodMaker/MethodMaker.xs
+++ b/deps/Class-MethodMaker/MethodMaker.xs
@@ -2,12 +2,17 @@
 #include "perl.h"
 #include "XSUB.h"
 
+/* inspired/stolen from Clone::Closure, to keep in sync with 5.13.3+ */
+#ifndef CvGV_set
+#define CvGV_set(cv,gv) CvGV(cv) = (gv)
+#endif
+
 MODULE = Class::MethodMaker PACKAGE = Class::MethodMaker
 
 void
 set_sub_name(SV *sub, char *pname, char *subname, char *stashname)
   CODE:
-    CvGV((GV*)SvRV(sub)) = gv_fetchpv(stashname, TRUE, SVt_PV);
+    CvGV_set((CV*)SvRV(sub), gv_fetchpv(stashname, TRUE, SVt_PV));
     GvSTASH(CvGV((GV*)SvRV(sub))) = gv_stashpv(pname, 1);
 #ifdef gv_name_set
     gv_name_set(CvGV((GV*)SvRV(sub)), subname, strlen(subname), GV_NOTQUAL);

--- a/gpgdir
+++ b/gpgdir
@@ -1276,7 +1276,8 @@ sub get_homedir() {
                 last;
             }
         }
-    } else {
+    }
+    if (!$homedir) {
         $homedir = $ENV{'HOME'} if defined $ENV{'HOME'};
     }
     &cleanup("[*] Could not determine home directory. Use the -u <homedir> option.")


### PR DESCRIPTION
- Fix #1  . This allows building Class:MethodMaker without installing it as a separate dependency.
- On Max OS X, the current user may not appear in /etc/passwd, but the $HOME variable is set correctly. Use $HOME if the current user cannot be extracted from /etc/passwd.